### PR TITLE
feat: add poolAndPositionKey free function for hook callbacks

### DIFF
--- a/src/libraries/PoolPositionKeyLib.sol
+++ b/src/libraries/PoolPositionKeyLib.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "v4-core/types/PoolId.sol";
+import {Position} from "v4-core/libraries/Position.sol";
+import {ModifyLiquidityParams} from "v4-core/types/PoolOperation.sol";
+
+using PoolIdLibrary for PoolKey;
+
+/// @notice Derives (PoolId, positionKey) from hook callback parameters in one call.
+/// @dev Avoids repeating key.toId() + Position.calculatePositionKey() in every hook.
+function poolAndPositionKey(
+    PoolKey calldata key,
+    address sender,
+    ModifyLiquidityParams calldata params
+) pure returns (PoolId id, bytes32 positionKey) {
+    id = key.toId();
+    positionKey = Position.calculatePositionKey(sender, params.tickLower, params.tickUpper, params.salt);
+}


### PR DESCRIPTION
## Summary

- Adds `poolAndPositionKey(PoolKey, address, ModifyLiquidityParams)` free function in `src/libraries/PoolPositionKeyLib.sol`
- Returns `(PoolId, bytes32 positionKey)` tuple, combining `key.toId()` + `Position.calculatePositionKey()` into one call
- Eliminates repeated boilerplate in `afterAddLiquidity` / `afterRemoveLiquidity` hook implementations

## Motivation

Every v4 hook that tracks per-position state needs to derive both `PoolId` and `positionKey` from the callback parameters. This is always the same two lines. A free function makes it a one-liner and keeps hook code focused on logic.

## Test plan

- [ ] `forge build --skip test --skip "src/tdd_*" --skip "src/Demo.sol"` compiles clean