### PR TITLE
fix: use @uniswap/v4-core/ imports for cross-project portability

### DIFF
--- a/src/libraries/PoolPositionKeyLib.sol
+++ b/src/libraries/PoolPositionKeyLib.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
-import {PoolKey} from "v4-core/types/PoolKey.sol";
-import {PoolId, PoolIdLibrary} from "v4-core/types/PoolId.sol";
-import {Position} from "v4-core/libraries/Position.sol";
-import {ModifyLiquidityParams} from "v4-core/types/PoolOperation.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {Position} from "@uniswap/v4-core/src/libraries/Position.sol";
+import {ModifyLiquidityParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
 
 using PoolIdLibrary for PoolKey;
 


### PR DESCRIPTION
## Summary

- Changes `v4-core/types/...` and `v4-core/libraries/...` imports in `PoolPositionKeyLib.sol` to `@uniswap/v4-core/src/...`
- The bare `v4-core/` prefix conflicts with `v4-core/src/` remappings in downstream projects (forge deduplicates the shorter prefix)
- `@uniswap/v4-core/src/` is the portable form that resolves in both this repo and consumers